### PR TITLE
Update QDataStream dependency and suggest ext-mbstring and mark all protocol classes as @internal only

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ The `close()` method can be used to force-close the Quassel connection immediate
 
 ## Install
 
-The recommended way to install this library is [through Composer](http://getcomposer.org).
-[New to Composer?](http://getcomposer.org/doc/00-intro.md)
+The recommended way to install this library is [through Composer](https://getcomposer.org).
+[New to Composer?](https://getcomposer.org/doc/00-intro.md)
 
 This will install the latest supported version:
 
@@ -147,10 +147,23 @@ $ composer require clue/quassel-react: ^0.5
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+HHVM.
+It's *highly recommended to use PHP 7+* for this project.
+
+Internally, it will use the `ext-mbstring` for converting between different
+character encodings for message strings.
+If this extension is missing, then special characters outside of ASCII/ISO5589-1
+range may be replaced with a `?` placeholder.
+This means that the string `hällo € 10!` may be converted as `hällo ? 10!`
+instead.
+Installing `ext-mbstring` is highly recommended.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all
-dependencies [through Composer](http://getcomposer.org):
+dependencies [through Composer](https://getcomposer.org):
 
 ```bash
 $ composer install

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "clue/quassel-react",
-    "description": "Simple streaming, event-driven access to your Quassel IRC core, built on top of ReactPHP",
+    "description": "Streaming, event-driven access to your Quassel IRC core, built on top of ReactPHP",
     "keywords": ["Quassel", "IRC", "ReactPHP", "async"],
     "homepage": "https://github.com/clue/php-quassel-react",
     "license": "MIT",
@@ -15,7 +15,7 @@
     },
     "require": {
     	"php": ">=5.3",
-        "clue/qdatastream": "^0.6",
+        "clue/qdatastream": "^0.7",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "~2.0|~1.1",
         "react/socket": "^1.0 || ^0.8 || ^0.7",
@@ -24,5 +24,8 @@
     "require-dev": {
         "clue/block-react": "^1.1",
         "phpunit/phpunit": "^5.0 || ^4.8"
+    },
+    "suggest": {
+        "ext-mbstring": "Used for converting character encodings for message strings"
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -283,13 +283,11 @@ class Client extends EventEmitter implements DuplexStreamInterface
      */
     public function write($data)
     {
-        if (isset($data[0])) {
-            $packet = $this->protocol->writeVariantList($data);
-        } else {
-            $packet = $this->protocol->writeVariantMap($data);
-        }
-
-        return $this->stream->write($this->splitter->writePacket($packet));
+        return $this->stream->write(
+            $this->splitter->writePacket(
+                $this->protocol->serializeVariantPacket($data)
+            )
+        );
     }
 
     public function end($data = null)
@@ -313,9 +311,8 @@ class Client extends EventEmitter implements DuplexStreamInterface
     public function handlePacket($packet)
     {
         // complete packet data received
-        // read variant from packet data and forward as message
-        $data = $this->protocol->readVariant($packet);
-        $this->emit('data', array($data));
+        // parse variant data from binary packet and forward as data event
+        $this->emit('data', array($this->protocol->parseVariantPacket($packet)));
     }
 
     /** @internal */

--- a/src/Client.php
+++ b/src/Client.php
@@ -142,7 +142,7 @@ class Client extends EventEmitter implements DuplexStreamInterface
     {
         return $this->write(array(
             Protocol::REQUEST_HEARTBEAT,
-            $this->createQVariantDateTime($dt)
+            $dt
         ));
     }
 
@@ -150,7 +150,7 @@ class Client extends EventEmitter implements DuplexStreamInterface
     {
         return $this->write(array(
             Protocol::REQUEST_HEARTBEATREPLY,
-            $this->createQVariantDateTime($dt)
+            $dt
         ));
     }
 
@@ -344,19 +344,5 @@ class Client extends EventEmitter implements DuplexStreamInterface
     public function handleDrain()
     {
         $this->emit('drain');
-    }
-
-    private function createQVariantDateTime(\DateTime $dt)
-    {
-        // The legacy protocol uses QTime which does not obey timezones or DST
-        // properties. Instead, convert everything to UTC so we send absolute
-        // timestamps irrespective of actual timezone.
-        if ($this->protocol->isLegacy()) {
-            $dt = clone $dt;
-            $dt->setTimeZone(new \DateTimeZone('UTC'));
-        }
-
-        // legacy protocol uses limited QTime while newer datagram protocol uses proper QDateTime
-        return new QVariant($dt, $this->protocol->isLegacy() ? Types::TYPE_QTIME : Types::TYPE_QDATETIME);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,11 @@ class Client extends EventEmitter implements DuplexStreamInterface
     private $protocol;
     private $splitter;
 
+    /**
+     * [internal] Constructor, see Factory instead
+     * @internal
+     * @see Factory
+     */
     public function __construct(DuplexStreamInterface $stream, Protocol $protocol = null, PacketSplitter $splitter = null)
     {
         if ($protocol === null) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,15 +2,14 @@
 
 namespace Clue\React\Quassel;
 
-use Clue\React\Quassel\Io\Protocol;
-use Clue\React\Quassel\Io\PacketSplitter;
-use Clue\React\Quassel\Io\Binary;
-use Evenement\EventEmitter;
-use Clue\QDataStream\Types;
 use Clue\QDataStream\QVariant;
-use React\Stream\WritableStreamInterface;
-use React\Stream\Util;
+use Clue\QDataStream\Types;
+use Clue\React\Quassel\Io\PacketSplitter;
+use Clue\React\Quassel\Io\Protocol;
+use Evenement\EventEmitter;
 use React\Stream\DuplexStreamInterface;
+use React\Stream\Util;
+use React\Stream\WritableStreamInterface;
 
 class Client extends EventEmitter implements DuplexStreamInterface
 {
@@ -29,7 +28,7 @@ class Client extends EventEmitter implements DuplexStreamInterface
             $protocol = Protocol::createFromProbe(0);
         }
         if ($splitter === null) {
-            $splitter = new PacketSplitter(new Binary());
+            $splitter = new PacketSplitter();
         }
 
         $this->stream = $stream;

--- a/src/Io/Binary.php
+++ b/src/Io/Binary.php
@@ -2,6 +2,7 @@
 
 namespace Clue\React\Quassel\Io;
 
+/** @internal */
 class Binary
 {
     public function writeUInt32($num)

--- a/src/Io/Binary.php
+++ b/src/Io/Binary.php
@@ -5,12 +5,12 @@ namespace Clue\React\Quassel\Io;
 /** @internal */
 class Binary
 {
-    public function writeUInt32($num)
+    public static function writeUInt32($num)
     {
         return pack('N', $num);
     }
 
-    public function readUInt32($data)
+    public static function readUInt32($data)
     {
         $d = unpack('Nint', $data);
 

--- a/src/Io/DatastreamProtocol.php
+++ b/src/Io/DatastreamProtocol.php
@@ -8,6 +8,7 @@ use Clue\QDataStream\QVariant;
 use Clue\QDataStream\Types;
 use InvalidArgumentException;
 
+/** @internal */
 class DatastreamProtocol extends Protocol
 {
     public function isLegacy()

--- a/src/Io/DatastreamProtocol.php
+++ b/src/Io/DatastreamProtocol.php
@@ -21,7 +21,7 @@ class DatastreamProtocol extends Protocol
             throw new InvalidArgumentException('List MUST start with an integer value in order to distinguish from map encoding');
         }
 
-        $writer = new Writer(null, $this->types, $this->userTypeWriter);
+        $writer = new Writer($this->userTypeWriter);
 
         // datastream protocol just uses list contents
         $writer->writeQVariantList($list);
@@ -31,7 +31,7 @@ class DatastreamProtocol extends Protocol
 
     public function writeVariantMap(array $map)
     {
-        $writer = new Writer(null, $this->types);
+        $writer = new Writer();
 
         // datastream protocol just uses list contents with UTF-8 keys
         // the list always starts with a key string, which can be used to tell apart from actual list contents
@@ -43,7 +43,7 @@ class DatastreamProtocol extends Protocol
 
     public function readVariant($packet)
     {
-        $reader = Reader::fromString($packet, $this->types, $this->userTypeReader);
+        $reader = new Reader($packet, $this->userTypeReader);
 
         // datastrema protocol always uses list contents (even for maps)
         $value = $reader->readQVariantList();

--- a/src/Io/LegacyProtocol.php
+++ b/src/Io/LegacyProtocol.php
@@ -12,27 +12,16 @@ class LegacyProtocol extends Protocol
         return true;
     }
 
-    public function writeVariantList(array $list)
+    public function serializeVariantPacket(array $data)
     {
+        // legacy protocol prefixes both list and map with variant information
         $writer = new Writer($this->userTypeWriter);
-
-        // legacy protocols prefixes list with type information
-        $writer->writeQVariant($list);
+        $writer->writeQVariant($data);
 
         return (string)$writer;
     }
 
-    public function writeVariantMap(array $map)
-    {
-        $writer = new Writer();
-
-        // legacy protocol prefixes map with type information
-        $writer->writeQVariant($map);
-
-        return (string)$writer;
-    }
-
-    public function readVariant($packet)
+    public function parseVariantPacket($packet)
     {
         $reader = new Reader($packet, $this->userTypeReader);
 

--- a/src/Io/LegacyProtocol.php
+++ b/src/Io/LegacyProtocol.php
@@ -4,6 +4,8 @@ namespace Clue\React\Quassel\Io;
 
 use Clue\QDataStream\Writer;
 use Clue\QDataStream\Reader;
+use Clue\QDataStream\QVariant;
+use Clue\QDataStream\Types;
 
 /** @internal */
 class LegacyProtocol extends Protocol
@@ -15,6 +17,13 @@ class LegacyProtocol extends Protocol
 
     public function serializeVariantPacket(array $data)
     {
+        // legacy ping requests will actually be sent as QTime which assumes UTC timezone
+        if (isset($data[0]) && ($data[0] === self::REQUEST_HEARTBEAT || $data[0] === self::REQUEST_HEARTBEATREPLY)) {
+            $dt = clone $data[1];
+            $dt->setTimeZone(new \DateTimeZone('UTC'));
+            $data[1] = new QVariant($dt, Types::TYPE_QTIME);
+        }
+
         // legacy protocol prefixes both list and map with variant information
         $writer = new Writer($this->userTypeWriter);
         $writer->writeQVariant($data);
@@ -24,17 +33,16 @@ class LegacyProtocol extends Protocol
 
     public function parseVariantPacket($packet)
     {
-        $reader = new Reader($packet, $this->userTypeReader);
-
         // legacy protcol always uses type prefix, so just read as variant
-        $q = $reader->readQVariant();
+        $reader = new Reader($packet, $this->userTypeReader);
+        $data = $reader->readQVariant();
 
         // ping requests will actually be sent as QTime which assumes UTC timezone
         // times will be returned with local timezone, so account for offset to UTC
-        if (isset($q[0]) && ($q[0] === self::REQUEST_HEARTBEAT || $q[0] === self::REQUEST_HEARTBEATREPLY)) {
-            $q[1]->modify($q[1]->getOffset() .  ' seconds');
+        if (isset($data[0]) && ($data[0] === self::REQUEST_HEARTBEAT || $data[0] === self::REQUEST_HEARTBEATREPLY)) {
+            $data[1]->modify($data[1]->getOffset() .  ' seconds');
         }
 
-        return $q;
+        return $data;
     }
 }

--- a/src/Io/LegacyProtocol.php
+++ b/src/Io/LegacyProtocol.php
@@ -5,6 +5,7 @@ namespace Clue\React\Quassel\Io;
 use Clue\QDataStream\Writer;
 use Clue\QDataStream\Reader;
 
+/** @internal */
 class LegacyProtocol extends Protocol
 {
     public function isLegacy()

--- a/src/Io/LegacyProtocol.php
+++ b/src/Io/LegacyProtocol.php
@@ -14,7 +14,7 @@ class LegacyProtocol extends Protocol
 
     public function writeVariantList(array $list)
     {
-        $writer = new Writer(null, $this->types, $this->userTypeWriter);
+        $writer = new Writer($this->userTypeWriter);
 
         // legacy protocols prefixes list with type information
         $writer->writeQVariant($list);
@@ -24,7 +24,7 @@ class LegacyProtocol extends Protocol
 
     public function writeVariantMap(array $map)
     {
-        $writer = new Writer(null, $this->types);
+        $writer = new Writer();
 
         // legacy protocol prefixes map with type information
         $writer->writeQVariant($map);
@@ -34,7 +34,7 @@ class LegacyProtocol extends Protocol
 
     public function readVariant($packet)
     {
-        $reader = Reader::fromString($packet, $this->types, $this->userTypeReader);
+        $reader = new Reader($packet, $this->userTypeReader);
 
         // legacy protcol always uses type prefix, so just read as variant
         $q = $reader->readQVariant();

--- a/src/Io/PacketSplitter.php
+++ b/src/Io/PacketSplitter.php
@@ -4,6 +4,7 @@ namespace Clue\React\Quassel\Io;
 
 use Clue\React\Quassel\Io\Binary;
 
+/** @internal */
 class PacketSplitter
 {
     private $buffer = '';

--- a/src/Io/PacketSplitter.php
+++ b/src/Io/PacketSplitter.php
@@ -8,12 +8,6 @@ use Clue\React\Quassel\Io\Binary;
 class PacketSplitter
 {
     private $buffer = '';
-    private $binary;
-
-    public function __construct(Binary $binary)
-    {
-        $this->binary = $binary;
-    }
 
     public function push($chunk, $fn)
     {
@@ -21,7 +15,7 @@ class PacketSplitter
 
         while (isset($this->buffer[3])) {
             // buffer contains at least packet length
-            $length = $this->binary->readUInt32(substr($this->buffer, 0, 4));
+            $length = Binary::readUInt32(substr($this->buffer, 0, 4));
 
             // buffer contains last byte of packet
             if (!isset($this->buffer[3 + $length])) {
@@ -50,6 +44,6 @@ class PacketSplitter
 
         // raw data is prefixed with length, then written
         // https://github.com/quassel/quassel/blob/master/src/common/remotepeer.cpp#L241
-        return $this->binary->writeUInt32(strlen($packet)) . $packet;
+        return Binary::writeUInt32(strlen($packet)) . $packet;
     }
 }

--- a/src/Io/Prober.php
+++ b/src/Io/Prober.php
@@ -5,6 +5,7 @@ namespace Clue\React\Quassel\Io;
 use React\Stream\DuplexStreamInterface;
 use React\Promise\Deferred;
 
+/** @internal */
 class Prober
 {
     const ERROR_PROTOCOL = 4;

--- a/src/Io/Prober.php
+++ b/src/Io/Prober.php
@@ -11,16 +11,6 @@ class Prober
     const ERROR_PROTOCOL = 4;
     const ERROR_CLOSED = 3;
 
-    private $binary;
-
-    public function __construct(Binary $binary = null)
-    {
-        if ($binary === null) {
-            $binary = new Binary();
-        }
-        $this->binary = $binary;
-    }
-
     public function probe(DuplexStreamInterface $stream, $compression = false, $encryption = false)
     {
         $magic = Protocol::MAGIC;
@@ -31,9 +21,7 @@ class Prober
             $magic |= Protocol::FEATURE_ENCRYPTION;
         }
 
-        $binary = $this->binary;
-
-        $stream->write($binary->writeUInt32($magic));
+        $stream->write(Binary::writeUInt32($magic));
 
         // list of supported protocol types (in order of preference)
         $types = array(Protocol::TYPE_DATASTREAM, Protocol::TYPE_LEGACY);
@@ -43,7 +31,7 @@ class Prober
         $types []= $last | Protocol::TYPELIST_END;
 
         foreach ($types as $type) {
-            $stream->write($binary->writeUInt32($type));
+            $stream->write(Binary::writeUInt32($type));
         }
 
         $deferred = new Deferred(function ($resolve, $reject) use ($stream) {
@@ -51,7 +39,7 @@ class Prober
         });
 
         $buffer = '';
-        $fn = function ($data) use (&$buffer, &$fn, $stream, $deferred, $binary) {
+        $fn = function ($data) use (&$buffer, &$fn, $stream, $deferred) {
             $buffer .= $data;
 
             if (isset($buffer[4])) {
@@ -62,7 +50,7 @@ class Prober
 
             if (isset($buffer[3])) {
                 $stream->removeListener('data', $fn);
-                $deferred->resolve($binary->readUInt32($buffer));
+                $deferred->resolve(Binary::readUInt32($buffer));
             }
         };
         $stream->on('data', $fn);

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -28,23 +28,20 @@ abstract class Protocol
     const REQUEST_HEARTBEAT = 5;
     const REQUEST_HEARTBEATREPLY = 6;
 
-    protected $binary;
     protected $userTypeReader;
     protected $userTypeWriter;
 
     public static function createFromProbe($probe)
     {
         if ($probe & self::TYPE_DATASTREAM) {
-            return new DatastreamProtocol(new Binary());
+            return new DatastreamProtocol();
         } else {
-            return new LegacyProtocol(new Binary());
+            return new LegacyProtocol();
         }
     }
 
-    public function __construct(Binary $binary)
+    public function __construct()
     {
-        $this->binary = $binary;
-
         $this->userTypeReader = array(
             // All required by SessionInit
             'NetworkId' => function (Reader $reader) {
@@ -120,26 +117,18 @@ abstract class Protocol
     abstract public function isLegacy();
 
     /**
-     * encode the given list of values
+     * encode the given list of values or map of key/value pairs to a binary packet
      *
-     * @param mixed[]|array<mixed> $list
+     * @param mixed[]|array<mixed> $data
      * @return string binary packet contents
      */
-    abstract public function writeVariantList(array $list);
-
-    /**
-     * encode the given map of key/value-pairs
-     *
-     * @param mixed[]|array<mixed> $map
-     * @return string binary packet contents
-     */
-    abstract public function writeVariantMap(array $map);
+    abstract public function serializeVariantPacket(array $data);
 
     /**
      * decodes the given packet contents and returns its representation in PHP
      *
-     * @param string $packet bianry packet contents
+     * @param string $packet binary packet contents
      * @return mixed[]|array<mixed> list of values or map of key/value-pairs
      */
-    abstract public function readVariant($packet);
+    abstract public function parseVariantPacket($packet);
 }

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -5,6 +5,7 @@ namespace Clue\React\Quassel\Io;
 use Clue\QDataStream\Writer;
 use Clue\QDataStream\Reader;
 
+/** @internal */
 abstract class Protocol
 {
     // https://github.com/quassel/quassel/blob/8e2f578b3d83d2dd7b6f2ea64d350693073ffed1/src/common/protocol.h#L30

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -3,7 +3,6 @@
 namespace Clue\React\Quassel\Io;
 
 use Clue\QDataStream\Writer;
-use Clue\QDataStream\Types;
 use Clue\QDataStream\Reader;
 
 abstract class Protocol
@@ -30,7 +29,6 @@ abstract class Protocol
     const REQUEST_HEARTBEATREPLY = 6;
 
     protected $binary;
-    protected $types;
     protected $userTypeReader;
     protected $userTypeWriter;
 
@@ -46,7 +44,6 @@ abstract class Protocol
     public function __construct(Binary $binary)
     {
         $this->binary = $binary;
-        $this->types = new Types();
 
         $this->userTypeReader = array(
             // All required by SessionInit

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -113,7 +113,7 @@ class ClientTest extends TestCase
 
     public function testDataEventWillBeForwardedFromSplitterThroughProtocolParser()
     {
-        $this->protocol->expects($this->once())->method('readVariant')->with('hello')->willReturn('parsed');
+        $this->protocol->expects($this->once())->method('parseVariantPacket')->with('hello')->willReturn('parsed');
         $this->client->on('data', $this->expectCallableOnceWith('parsed'));
 
         $this->client->handlePacket('hello');
@@ -169,7 +169,7 @@ class ClientTest extends TestCase
         $dt = new \DateTime();
 
         $this->protocol->expects($this->any())->method('isLegacy')->willReturn(true);
-        $this->protocol->expects($this->once())->method('writeVariantList')->with(array(
+        $this->protocol->expects($this->once())->method('serializeVariantPacket')->with(array(
             Protocol::REQUEST_HEARTBEAT,
             new QVariant($dt, Types::TYPE_QTIME)
         ));
@@ -183,7 +183,7 @@ class ClientTest extends TestCase
         $dt = new \DateTime();
 
         $this->protocol->expects($this->any())->method('isLegacy')->willReturn(false);
-        $this->protocol->expects($this->once())->method('writeVariantList')->with(array(
+        $this->protocol->expects($this->once())->method('serializeVariantPacket')->with(array(
             Protocol::REQUEST_HEARTBEAT,
             new QVariant($dt, Types::TYPE_QDATETIME)
         ));
@@ -194,7 +194,7 @@ class ClientTest extends TestCase
 
     private function expectWriteMap()
     {
-        $this->protocol->expects($this->once())->method('writeVariantMap');
+        $this->protocol->expects($this->once())->method('serializeVariantPacket');
         $this->splitter->expects($this->once())->method('writePacket');
         $this->stream->expects($this->once())->method('write');
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -161,31 +161,22 @@ class ClientTest extends TestCase
     {
         $dt = new \DateTime();
 
-        $this->client->writeHeartBeatRequest($dt);
-    }
-
-    public function testWriteHeartBeatReplyLegacyAsQTime()
-    {
-        $dt = new \DateTime();
-
-        $this->protocol->expects($this->any())->method('isLegacy')->willReturn(true);
         $this->protocol->expects($this->once())->method('serializeVariantPacket')->with(array(
-            Protocol::REQUEST_HEARTBEAT,
-            new QVariant($dt, Types::TYPE_QTIME)
+            Protocol::REQUEST_HEARTBEATREPLY,
+            $dt
         ));
         $this->splitter->expects($this->once())->method('writePacket');
 
-        $this->client->writeHeartBeatRequest($dt);
+        $this->client->writeHeartBeatReply($dt);
     }
 
-    public function testWriteHeartBeatReplyNonLegacyAsQDateTime()
+    public function testWriteHeartBeatReply()
     {
         $dt = new \DateTime();
 
-        $this->protocol->expects($this->any())->method('isLegacy')->willReturn(false);
         $this->protocol->expects($this->once())->method('serializeVariantPacket')->with(array(
             Protocol::REQUEST_HEARTBEAT,
-            new QVariant($dt, Types::TYPE_QDATETIME)
+            $dt
         ));
         $this->splitter->expects($this->once())->method('writePacket');
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,8 +2,6 @@
 
 use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Io\Protocol;
-use Clue\QDataStream\QVariant;
-use Clue\QDataStream\Types;
 use React\Stream\ThroughStream;
 
 class ClientTest extends TestCase

--- a/tests/Io/AbstractProtocolTest.php
+++ b/tests/Io/AbstractProtocolTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Clue\React\Quassel\Io\Protocol;
-use Clue\React\Quassel\Io\Binary;
-use Clue\React\Quassel\Io\PacketParser;
-use Clue\QDataStream\Reader;
 use Clue\QDataStream\QVariant;
 
 abstract class AbstractProtocolTest extends TestCase
@@ -14,28 +11,28 @@ abstract class AbstractProtocolTest extends TestCase
     {
         $in = array(1, 'first', 'second', 10, false);
 
-        $packet = $this->protocol->writeVariantList($in);
+        $packet = $this->protocol->serializeVariantPacket($in);
 
-        $this->assertEquals($in, $this->protocol->readVariant($packet));
+        $this->assertEquals($in, $this->protocol->parseVariantPacket($packet));
     }
 
     public function testVariantMap()
     {
         $in = array('hello' => 'world', 'number' => 10, 'boolean' => true);
 
-        $packet = $this->protocol->writeVariantMap($in);
+        $packet = $this->protocol->serializeVariantPacket($in);
 
-        $this->assertEquals($in, $this->protocol->readVariant($packet));
+        $this->assertEquals($in, $this->protocol->parseVariantPacket($packet));
     }
 
     public function testUserTypeBufferId()
     {
-        $packet = $this->protocol->writeVariantList(array(
+        $packet = $this->protocol->serializeVariantPacket(array(
             1000,
             new QVariant(10, 'BufferId')
         ));
 
-        $out = $this->protocol->readVariant($packet);
+        $out = $this->protocol->parseVariantPacket($packet);
 
         $this->assertEquals(array(1000, 10), $out);
     }

--- a/tests/Io/AbstractProtocolTest.php
+++ b/tests/Io/AbstractProtocolTest.php
@@ -25,6 +25,17 @@ abstract class AbstractProtocolTest extends TestCase
         $this->assertEquals($in, $this->protocol->parseVariantPacket($packet));
     }
 
+    public function testHeartBeatWithCorrectTimeZoneAndMillisecondAccuracy()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $in = array(Protocol::REQUEST_HEARTBEAT, new DateTime('12:34:56.789'));
+
+        $packet = $this->protocol->serializeVariantPacket($in);
+
+        $this->assertEquals($in, $this->protocol->parseVariantPacket($packet));
+    }
+
     public function testUserTypeBufferId()
     {
         $packet = $this->protocol->serializeVariantPacket(array(

--- a/tests/Io/BinaryTest.php
+++ b/tests/Io/BinaryTest.php
@@ -4,20 +4,15 @@ use Clue\React\Quassel\Io\Binary;
 
 class BinaryTest extends TestCase
 {
-    public function setUp()
-    {
-        $this->binary = new Binary();
-    }
-
     public function testZero()
     {
-        $this->assertEquals("\0\0\0\0", $this->binary->writeUInt32(0));
-        $this->assertEquals(0, $this->binary->readUInt32("\0\0\0\0"));
+        $this->assertEquals("\0\0\0\0", Binary::writeUInt32(0));
+        $this->assertEquals(0, Binary::readUInt32("\0\0\0\0"));
     }
 
     public function test18()
     {
-        $this->assertEquals("\0\0\0\x12", $this->binary->writeUInt32(18));
-        $this->assertEquals(18, $this->binary->readUInt32("\0\0\0\x12"));
+        $this->assertEquals("\0\0\0\x12", Binary::writeUInt32(18));
+        $this->assertEquals(18, Binary::readUInt32("\0\0\0\x12"));
     }
 }

--- a/tests/Io/DatastreamProtocolTest.php
+++ b/tests/Io/DatastreamProtocolTest.php
@@ -22,7 +22,7 @@ class DatastreamProtocolTest extends AbstractProtocolTest
      */
     public function testCanNotTransportListStartingWithString()
     {
-        $this->protocol->writeVariantList(array('does', 'not', 'work'));
+        $this->protocol->serializeVariantPacket(array('does', 'not', 'work'));
     }
 
     public function testInitDataWireFormatWillBeRepresentedLikeLegacyProtocol()
@@ -33,7 +33,7 @@ class DatastreamProtocolTest extends AbstractProtocolTest
         // the actual message interpretation (in line with legacy protocol wire format)
         $expected = array(Protocol::REQUEST_INITDATA, 'Network', '1', array('k1' => 'v1', 'k2' => 'v2'));
 
-        $this->assertEquals($expected, $this->protocol->readVariant($this->protocol->writeVariantList($message)));
+        $this->assertEquals($expected, $this->protocol->parseVariantPacket($this->protocol->serializeVariantPacket($message)));
     }
 
     public function testReceiveHeartBeatRequestWithCorrectTimeZone()
@@ -48,7 +48,7 @@ class DatastreamProtocolTest extends AbstractProtocolTest
 
         $packet = (string)$writer;
 
-        $values = $this->protocol->readVariant($packet);
+        $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(2, $values);
         $this->assertEquals(Protocol::REQUEST_HEARTBEAT, $values[0]);

--- a/tests/Io/LegacyProtocolTest.php
+++ b/tests/Io/LegacyProtocolTest.php
@@ -34,7 +34,7 @@ class LegacyProtocolTest extends AbstractProtocolTest
 
         $packet = (string)$writer;
 
-        $values = $this->protocol->readVariant($packet);
+        $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(2, $values);
         $this->assertEquals(Protocol::REQUEST_HEARTBEAT, $values[0]);
@@ -53,7 +53,7 @@ class LegacyProtocolTest extends AbstractProtocolTest
 
         $packet = (string)$writer;
 
-        $values = $this->protocol->readVariant($packet);
+        $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(2, $values);
         $this->assertEquals(Protocol::REQUEST_HEARTBEAT, $values[0]);
@@ -72,7 +72,7 @@ class LegacyProtocolTest extends AbstractProtocolTest
 
         $packet = (string)$writer;
 
-        $values = $this->protocol->readVariant($packet);
+        $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(2, $values);
         $this->assertEquals(Protocol::REQUEST_HEARTBEATREPLY, $values[0]);

--- a/tests/Io/PacketSplitterTest.php
+++ b/tests/Io/PacketSplitterTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Clue\React\Quassel\Io\PacketSplitter;
-use Clue\React\Quassel\Io\Binary;
 
 class PacketSplitterTest extends TestCase
 {
@@ -9,7 +8,7 @@ class PacketSplitterTest extends TestCase
 
     public function setUp()
     {
-        $this->splitter = new PacketSplitter(new Binary());
+        $this->splitter = new PacketSplitter();
     }
 
     public function testWillEmitOnceCompletePacketIsWritten()


### PR DESCRIPTION
Marking this as BC break just to be sure as it technically affects the public API, but this should actually not affect consumer code.