### PR TITLE
Report error if connection ends while receiving data and simplify close logic to remove all event listeners once closed

### DIFF
--- a/examples/01-channels.php
+++ b/examples/01-channels.php
@@ -100,6 +100,11 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
         echo 'received unhandled: ' . json_encode($message, JSON_PRETTY_PRINT) . PHP_EOL;
     });
 
+    $client->on('error', 'printf');
+    $client->on('close', function () {
+        echo 'Connection closed' . PHP_EOL;
+    });
+
     $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -90,6 +90,11 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
         }
     });
 
+    $client->on('error', 'printf');
+    $client->on('close', function () {
+        echo 'Connection closed' . PHP_EOL;
+    });
+
     $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -127,6 +127,11 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
         }
     });
 
+    $client->on('error', 'printf');
+    $client->on('close', function () {
+        echo 'Connection closed' . PHP_EOL;
+    });
+
     $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -125,17 +125,12 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user,
         echo 'received unhandled: ' . json_encode($message) . PHP_EOL;
     });
 
+    $client->on('error', 'printf');
+    $client->on('close', function () {
+        echo 'Connection closed' . PHP_EOL;
+    });
+
     $client->writeClientInit();
-
-    $client->on('close', function () use (&$timer, $loop) {
-        var_dump('CLOSED');
-        $loop->cancelTimer($timer);
-    });
-
-    $timer = $loop->addTimer(60.0 * 60, function ($timer) use ($client) {
-        var_dump('connection expired after ' . $timer->getInterval() . ' seconds');
-        $client->close();
-    });
 })->then(null, function ($e) {
     echo $e;
 });

--- a/src/Client.php
+++ b/src/Client.php
@@ -326,8 +326,12 @@ class Client extends EventEmitter implements DuplexStreamInterface
     /** @internal */
     public function handleEnd()
     {
-        $this->emit('end');
-        $this->close();
+        if ($this->splitter->isEmpty()) {
+            $this->emit('end');
+            $this->close();
+        } else {
+            $this->handleError(new \RuntimeException('Connection ended while receiving data'));
+        }
     }
 
     /** @internal */

--- a/src/Io/PacketSplitter.php
+++ b/src/Io/PacketSplitter.php
@@ -44,6 +44,16 @@ class PacketSplitter
     }
 
     /**
+     * Checks whether there's any incomplete data in the incoming buffer
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return ($this->buffer === '');
+    }
+
+    /**
      * encode the given packet data to include framing (packet length)
      *
      * @param string $packet binary packet contents

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -27,6 +27,15 @@ class ClientTest extends TestCase
         $this->client->close();
     }
 
+    public function testClosingClientEmitsCloseEventAndRemovesListeners()
+    {
+        $this->client->on('close', $this->expectCallableOnce());
+        $this->assertCount(1, $this->client->listeners('close'));
+
+        $this->client->close();
+        $this->assertEquals(array(), $this->client->listeners('close'));
+    }
+
     public function testIsReadableWillReturnFromUnderlyingStream()
     {
         $this->stream->expects($this->once())->method('isReadable')->willReturn(true);


### PR DESCRIPTION
This fixes a subtle bug that could cause outstanding events to be emitted after the connection closed.

Builds on top of #29