### PR TITLE
Only support optional quassel:// URI scheme and always use probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,20 @@ $factory->createClient('localhost')->then(
 );
 ```
 
-The `$uri` parameter must be a valid URI which must contain a host part and can optionally contain a port.
-
-This method defauls to probing the Quassel IRC core for the correct protocol to
-use (newer "datastream" protocol or original "legacy" protocol).
-If you have trouble with the newer "datastream" protocol, you can force using
-the old "legacy" protocol by prefixing the `legacy` scheme identifier like this:
+The `$uri` parameter must be a valid URI which must contain a host part and can
+optionally be preceded by the `quassel://` URI scheme and may contain a port
+if your Quassel IRC core is not using the default TCP/IP port `4242`:
 
 ```php
-$factory->createClient('legacy://quassel.example.com:1234');
+$factory->createClient('quassel://localhost:4242');
 ```
+
+>   This method uses Quassel IRC's probing mechanism for the correct protocol to
+    use (newer "datastream" protocol or original "legacy" protocol).
+    Protocol handling will be abstracted away for you, so you don't have to
+    worry about this (see also below for more details about protocol messages).
+    Note that this project does not currently implement encryption and
+    compression support.
 
 ### Client
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -26,57 +26,47 @@ class Factory
         $this->prober = $prober;
     }
 
-    public function createClient($address)
+    public function createClient($uri)
     {
-        if (strpos($address, '://') === false) {
-            $address = 'tcp://' . $address;
+        if (strpos($uri, '://') === false) {
+            $uri= 'quassel://' . $uri;
         }
-        $parts = parse_url($address);
-        if (!$parts || !isset($parts['host'])) {
-            return Promise\reject(new InvalidArgumentException('Given argument "' . $address . '" is not a valid URI'));
+        $parts = parse_url($uri);
+        if (!$parts || !isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'quassel') {
+            return Promise\reject(new InvalidArgumentException('Given argument "' . $uri. '" is not a valid Quassel URI'));
         }
         if (!isset($parts['port'])) {
             $parts['port'] = 4242;
         }
 
-        // default to automatic probing protocol unless scheme is explicitly given
-        $probe = 0;
-        if (isset($parts['scheme'])) {
-            if ($parts['scheme'] === 'legacy') {
-                $probe = Protocol::TYPE_LEGACY;
-            } elseif ($parts['scheme'] !== 'tcp') {
-                return Promise\reject(new InvalidArgumentException('Given URI scheme "' . $parts['scheme'] . '" is invalid'));
-            }
-        }
-
+        // establish low-level TCP/IP connection to Quassel IRC core
         $promise = $this->connector->connect($parts['host'] . ':' . $parts['port']);
 
-        // protocol probe not already set
-        if ($probe === 0) {
-            $connector = $this->connector;
-            $prober = $this->prober;
+        // probe protocol once connected
+        $probe = 0;
+        $connector = $this->connector;
+        $prober = $this->prober;
+        $promise = $promise->then(function (DuplexStreamInterface $stream) use ($prober, &$probe, $connector, $parts) {
+            return $prober->probe($stream)->then(
+                function ($ret) use (&$probe, $stream) {
+                    // probe returned successfully, create new client for this stream
+                    $probe = $ret;
 
-            $promise = $promise->then(function (DuplexStreamInterface $stream) use ($prober, &$probe, $connector, $parts) {
-                return $prober->probe($stream)->then(
-                    function ($ret) use (&$probe, $stream) {
-                        // probe returned successfully, create new client for this stream
-                        $probe = $ret;
-
-                        return $stream;
-                    },
-                    function ($e) use ($connector, $parts) {
-                        // probing failed
-                        if ($e->getCode() === Prober::ERROR_CLOSED) {
-                            // legacy servers will terminate connection while probing
-                            // let's just open a new connection and assume default probe
-                            return $connector->connect($parts['host'] . ':' . $parts['port']);
-                        }
-                        throw $e;
+                    return $stream;
+                },
+                function ($e) use ($connector, $parts) {
+                    // probing failed
+                    if ($e->getCode() === Prober::ERROR_CLOSED) {
+                        // legacy servers will terminate connection while probing
+                        // let's just open a new connection and assume default probe
+                        return $connector->connect($parts['host'] . ':' . $parts['port']);
                     }
-                );
-            });
-        }
+                    throw $e;
+                }
+            );
+        });
 
+        // decorate client once probing is finished
         return $promise->then(
             function (DuplexStreamInterface $stream) use (&$probe) {
                 return new Client($stream, Protocol::createFromProbe($probe));

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -28,11 +28,11 @@ class FactoryTest extends TestCase
         $this->factory->createClient('example.com');
     }
 
-    public function testPassHostnameAndPortToConnector()
+    public function testFullUriWithUnneededComponentsPassHostnameAndPortToConnector()
     {
         $deferred = new Deferred();
         $this->connector->expects($this->once())->method('connect')->with($this->equalTo('example.com:1234'))->will($this->returnValue($deferred->promise()));
-        $this->factory->createClient('example.com:1234');
+        $this->factory->createClient('quassel://example.com:1234/ignored?ignored#ignored');
     }
 
     public function testInvalidUriWillRejectWithoutConnecting()
@@ -57,15 +57,5 @@ class FactoryTest extends TestCase
         $this->prober->expects($this->once())->method('probe')->with($this->equalTo($stream))->will($this->returnValue(Promise\resolve(Protocol::TYPE_DATASTREAM)));
 
         $this->expectPromiseResolve($this->factory->createClient('localhost'));
-    }
-
-    public function testWillNotInvokeProberIfSchemeIsProtocol()
-    {
-        $stream = $this->getMockBuilder('React\Stream\DuplexStreamInterface')->getMock();
-
-        $this->connector->expects($this->once())->method('connect')->will($this->returnValue(Promise\resolve($stream)));
-        $this->prober->expects($this->never())->method('probe');
-
-        $this->expectPromiseResolve($this->factory->createClient('legacy://localhost'));
     }
 }


### PR DESCRIPTION
We no longer expose any differences between the low-level legacy and newer datastream protocols, so we only expose this as the `quassel://` URI scheme.

Builds on top of #27