### PR TITLE
 Automatically send current timestamp for heartbeat requests by default unless explicit timestamp is given

### DIFF
--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -64,8 +64,13 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
             var_dump('session initialized, now waiting for incoming messages');
 
             // send heartbeat message every 30s to check dropped connection
-            $loop->addPeriodicTimer(30.0, function () use ($client) {
+            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
                 $client->writeHeartBeatRequest(new \DateTime());
+            });
+
+            // stop heartbeat timer once connection closes
+            $client->on('close', function () use ($loop, $timer) {
+                $loop->cancelTimer($timer);
             });
 
             return;

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -65,7 +65,7 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
 
             // send heartbeat message every 30s to check dropped connection
             $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest(new \DateTime());
+                $client->writeHeartBeatRequest();
             });
 
             // stop heartbeat timer once connection closes

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -65,7 +65,7 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
 
             // send heartbeat message every 30s to check dropped connection
             $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest(new \DateTime());
+                $client->writeHeartBeatRequest();
             });
 
             // stop heartbeat timer once connection closes

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -64,8 +64,13 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
             }
 
             // send heartbeat message every 30s to check dropped connection
-            $loop->addPeriodicTimer(30.0, function () use ($client) {
+            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
                 $client->writeHeartBeatRequest(new \DateTime());
+            });
+
+            // stop heartbeat timer once connection closes
+            $client->on('close', function () use ($loop, $timer) {
+                $loop->cancelTimer($timer);
             });
 
             return;

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -31,7 +31,7 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user,
         });
     }
 
-    $client->on('data', function ($message) use ($client, $user) {
+    $client->on('data', function ($message) use ($client, $user, $loop) {
         $type = null;
         if (is_array($message) && isset($message['MsgType'])) {
             $type = $message['MsgType'];
@@ -93,6 +93,16 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user,
                 }
             }
 
+            // send heartbeat message every 30s to check dropped connection
+            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
+                $client->writeHeartBeatRequest(new \DateTime());
+            });
+
+            // stop heartbeat timer once connection closes
+            $client->on('close', function () use ($loop, $timer) {
+                $loop->cancelTimer($timer);
+            });
+
             var_dump('initialization completed, now waiting for incoming messages (assuming core receives any)');
 
             return;
@@ -103,10 +113,16 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user,
             $type = $message[0];
         }
 
+        // reply to heartbeat messages to avoid timing out
         if ($type === Protocol::REQUEST_HEARTBEAT) {
             //var_dump('heartbeat', $message[1]);
             $client->writeHeartBeatReply($message[1]);
 
+            return;
+        }
+
+        // ignore heartbeat reply messages to our heartbeat requests
+        if ($type === Protocol::REQUEST_HEARTBEATREPLY) {
             return;
         }
 

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -95,7 +95,7 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user,
 
             // send heartbeat message every 30s to check dropped connection
             $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest(new \DateTime());
+                $client->writeHeartBeatRequest();
             });
 
             // stop heartbeat timer once connection closes

--- a/src/Client.php
+++ b/src/Client.php
@@ -138,14 +138,51 @@ class Client extends EventEmitter implements DuplexStreamInterface
         ));
     }
 
-    public function writeHeartBeatRequest(\DateTime $dt)
+    /**
+     * Sends a heartbeat request
+     *
+     * Expect the Quassel IRC core to respond with a heartbeat reply with the
+     * same Datetime object with millisecond precision.
+     *
+     * Giving a DateTime object is optional because the most common use case is
+     * to send the current timestamp. It is recommended to not give one so the
+     * appropriate timestamp is sent automatically. Otherwise, you should make
+     * sure to use a DateTime object with appropriate precision.
+     *
+     * Note that the Quassel protocol limits the DateTime accuracy to
+     * millisecond precision and incoming DateTime objects will always be
+     * expressed in the current default timezone. Also note that the legacy
+     * protocol only transports number of milliseconds since midnight, so this
+     * is not suited a transport arbitrary timestamps.
+     *
+     * @param null|\DateTime $dt (optional) DateTime object with millisecond precision or null=current timestamp
+     * @return bool
+     */
+    public function writeHeartBeatRequest(\DateTime $dt = null)
     {
+        if ($dt === null) {
+            $dt = \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+        }
+
         return $this->write(array(
             Protocol::REQUEST_HEARTBEAT,
             $dt
         ));
     }
 
+    /**
+     * Sends a heartbeat reply
+     *
+     * This should be sent in response to an incoming heartbeat request from
+     * the Quassel IRC core.
+     *
+     * Giving a DateTime object is mandatory because the most common use case is
+     * responding with the same timestamp that was given in the incoming
+     * heartbeat request message.
+     *
+     * @param \DateTime $dt
+     * @return boolean
+     */
     public function writeHeartBeatReply(\DateTime $dt)
     {
         return $this->write(array(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -190,7 +190,7 @@ class ClientTest extends TestCase
         $this->client->writeCoreSetupData('user', 'pass', 'PQSql', array('password' => 'test'));
     }
 
-    public function testWriteHeartBeatRequest()
+    public function testWriteHeartBeatReply()
     {
         $dt = new \DateTime();
 
@@ -203,7 +203,7 @@ class ClientTest extends TestCase
         $this->client->writeHeartBeatReply($dt);
     }
 
-    public function testWriteHeartBeatReply()
+    public function testWriteHeartBeatRequest()
     {
         $dt = new \DateTime();
 
@@ -214,6 +214,22 @@ class ClientTest extends TestCase
         $this->splitter->expects($this->once())->method('writePacket');
 
         $this->client->writeHeartBeatRequest($dt);
+    }
+
+    public function testWriteHeartBeatRequestWithoutTimestampSendsCurrentTimestamp()
+    {
+        $that = $this;
+        $this->protocol->expects($this->once())->method('serializeVariantPacket')->with($this->callback(function ($value) use ($that) {
+            $that->assertCount(2, $value);
+            $that->assertEquals(Protocol::REQUEST_HEARTBEAT, $value[0]);
+
+            $that->assertInstanceOf('DateTime', $value[1]);
+            $that->assertEquals(microtime(true), $value[1]->getTimestamp(), '', 2);
+            return true;
+        }));
+        $this->splitter->expects($this->once())->method('writePacket');
+
+        $this->client->writeHeartBeatRequest();
     }
 
     private function expectWriteMap()


### PR DESCRIPTION
Builds on top of #30